### PR TITLE
Missing true parameter for force open inventory export

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -223,7 +223,7 @@ end)
 ---@param invType string
 ---@param data string|number|table
 exports('forceOpenInventory', function(playerId, invType, data)
-	local left, right = openInventory(playerId, invType, data)
+	local left, right = openInventory(playerId, invType, data, true)
 
 	if left and right then
 		TriggerClientEvent('ox_inventory:forceOpenInventory', playerId, left, right)


### PR DESCRIPTION
Force open inventory was meant to disable all the security checks but it was never passed to the openInventory function.